### PR TITLE
Fix/disable write mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4 - Disable `write-mode`
+* see https://github.com/rust-lang/rustfmt/issues/2543
+
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/lib/rustfmt.js
+++ b/lib/rustfmt.js
@@ -42,7 +42,7 @@ export default {
     },
 
     format(file) {
-        new BufferedProcess({command: atom.config.get('rustfmt.binPath'), args: ['--write-mode=overwrite', file]});
+        new BufferedProcess({command: atom.config.get('rustfmt.binPath'), args: [file]});
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rustfmt",
   "main": "./lib/rustfmt",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Format rust source code with rustfmt",
   "keywords": [
     "rust",


### PR DESCRIPTION
Hi,

it looks like `rustfmt`/ `cargo fmt` doesn't support `--write-mode` anymore. See https://github.com/rust-lang/rustfmt/issues/2543 for that.